### PR TITLE
英訳を最新化、core-memberチャンネルの命名規約追加

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,20 +1,20 @@
 # JAWS-UG Manifesto
 
-JAWS-UG is a user group of Amazon Web Services. It is a user group for learning about AWS services, discussing and sharing knowledge.
+JAWS-UG (pronounced “jawz-ug”) is a user group for Amazon Web Services. It is a user group for learning about, discussing, and sharing knowledge about AWS services.
 
-The following sentences are the code of conduct we want you to observe for everyone involved in JAWS-UG. These were created with the following objectives.
+The following text is a code of conduct that we ask everyone involved with JAWS-UG to follow. These were created with the following objectives in mind
 
-* Sharing action guidelines in managing JAWS-UG
-* Clarification of expectations and unexpectations for community activities under the name of JAWS-UG
+* To share a code of conduct for operating JAWS-UG
+* Clarification of what is and is not expected of community activities conducted in the name of JAWS-UG
 
-JAWS - UG welcomes everyone who contributes to the community. We are waiting for everyone's participation.
+JAWS-UG welcomes everyone who contributes to the community. We look forward to your participation.
 
-# Currently in line with the Code of Conduct
+# Currently maintained code of conduct
 
-* [JAWS-UG Operation Code of Conduct] (for-contributors.md)
+* [JAWS-UG Administration Code of Conduct](for-contributors.md)
 
 # Code of conduct to be created
 
-* Code of conduct for event organizers
-* Sponsors' Guidelines
-* Guidelines for Experts
+* Code of Conduct for Event Organizers
+* Guidelines for Sponsors
+* Guidelines for Speakers

--- a/for-contributors.en.md
+++ b/for-contributors.en.md
@@ -70,8 +70,8 @@ Chapters that are active and displayed on the [list of study groups](https://jaw
 The switch from “active” to “inactive” is done in the following order.
 - At the JAWS-UG general meeting held every March, we will contact chapters that have not held any study sessions for 12 months.
 - Chapters that have not held any study sessions for one month after being contacted will be treated as “inactive”.
-- We will contact the JAWS-UG General Assembly, #core-members${yyyymm}, and [Chapter Representatives](https://docs.google.com/spreadsheets/d/18ceDqZoXyFT92S7MwsvS9a6SrKnd0D1gssKJkDzIE4g/edit?usp=sharing), but even if we are unable to contact them, they will be treated as “inactive”.
-- yyyymm is created in units of years
+- We will contact the JAWS-UG General Assembly, #core-members${yyyy}, and [Chapter Representatives](https://docs.google.com/spreadsheets/d/18ceDqZoXyFT92S7MwsvS9a6SrKnd0D1gssKJkDzIE4g/edit?usp=sharing), but even if we are unable to contact them, they will be treated as “inactive”.
+- yyyy is created in units of years
 
 #### Changing to an active status
 The switch from “inactive” to “active” is done in the following order.

--- a/for-contributors.en.md
+++ b/for-contributors.en.md
@@ -1,65 +1,86 @@
-# JAWS - UG Operation Code of Conduct - Code of Conduct -
+# JAWS-UG Administration Code of Conduct - Code of Conduct -
 
-Everyone who is doing community activities under the name of JAWS-UG, or who wishes to pursue it, please try to comply with the following code of conduct. This is a valid behavioral code for both online and offline.
+All those who are or will be engaged in community activities in the name of JAWS-UG are requested to observe the following code of conduct. This code of conduct is valid both online and offline.
 
+## JAWS-UG Community Philosophy
 
-## Philosophy of the JAWS-UG community
+The community that operates under the name of JAWS-UG should treat AWS, provided by Amazon Web Services Japan (AWS Japan), with love. The use of the JAWS-UG name for excessive self-promotion, job recruitment, or other commercial purposes is never allowed.
 
-Please be aware that the community operated under the name of JAWS-UG is lovingly connected with AWS provided by Amazon Web Services Japan G.K. (AWS Japan). It is never permitted to use the name of JAWS-UG for excessive propaganda, recruitment, or other commercial purposes.
+## Expected behavior
 
-# Expected behavior
+* To the extent possible, please provide your abilities to the community. The community exists because of your contributions.
+* Please remember to be considerate of those who are new to the community. Remember that the first time anyone comes into contact with a community can be a scary experience.
+* Please do your best to ensure that all participants, including those who are new to the event, can enjoy the event.
 
-* To the extent possible, please provide your community with the capabilities you have. It is the community of your contribution.
-* Please do not forget to give consideration to "people who join the community for the first time" anytime. Do not forget that the moment anyone touches the community for the first time is scary.
-* Please take care as much as possible so that all participants can participate in the event happily, including those who first came to the event.
+## Unacceptable behavior
 
-
-# Unexpected behavior
-
-* There is no contribution to the community, it is not appropriate to reveal its influence by borrowing just the name of JAWS-UG.
-* It is not appropriate to raise a part of the story with only staff members in the event venue, abbreviations that are not common, story like inner ring story, etc. that only leads to themselves.
-* Criticism, torture, scolding, etc. are not appropriate unless they are carried out with mutual love and consideration.
-* The expression relating to race, gender, sexual orientation, physical characteristics, appearance, politics, religion (or non-religion) etc of the person concerned is not appropriate in any case.
-
+* It is not appropriate to use the JAWS-UG name to show off your influence without contributing to the community.
+* It is not appropriate for the organizing members to hang out together at the event venue, or to get excited about things that only they understand, such as using unusual abbreviations or talking about inside jokes.
+* It is not appropriate to criticize, abuse or ridicule each other, unless you do so with love and affection.
+* Expressions related to the race, gender, sexual orientation, physical characteristics, appearance, politics, religion (or lack of religion) etc. of those involved are not appropriate in any case.
 
 # Structure of JAWS-UG
 
-## structural unit
+## Constituent Units
 
-Communities operated under the name of JAWS-UG are grouped according to specific areas, specific interests, etc. and require that they be composed of units called "branches". However, this branch may exist either online or offline.
+The community that operates under the name of JAWS-UG is required to be composed of units called “chapters”, which are grouped according to specific regions, specific interests, etc. However, these chapters may exist either online or offline.
+
+## Structure of the Management Team
+
+The JAWS-UG management team welcomes all those who contribute to the JAWS-UG community as core members. Core members are grouped into chapters, and all members are honored as contributors representing their chapters.
+
+We assume that participation in the core members is usually preceded by some kind of contribution, or by the establishment of mutual respect and trust with other core members during the preparation stage of a project that you intend to contribute to.
+
+All core members within a chapter have a flat relationship, but of course it is possible that core members who can bring together the opinions within the chapter or take on specific tasks will arise spontaneously or inevitably. In such cases, there is no problem with them calling themselves “Publicity Manager”, “Banquet Manager”, “Advertising Sales”, “Liaison Officer”, etc. externally, but this is not considered to be authority, but a role (role).
+
+## About starting a new chapter
+
+If you are a contributor who wants to discuss a topic that is not being discussed by an existing chapter or there is no chapter in your area, you can freely start a new chapter. Please contact existing contributors.
+
+However, before planning to start a new chapter, please try to visit existing study sessions and events to get a feel for the atmosphere. It is not too late to start planning to start a chapter after communicating with the core members who are managing the study sessions and getting a grasp of the actual management.
+
+There are several preconditions for establishing a branch.
+
+In the past, there have been cases where branches have been set up but then stopped after the initial launch event. To avoid this, we believe it is essential to have follow-up support from other branches and the secretariat, and we have a number of requests for this purpose that are preconditions.
 
 
-# Structure of the management team
+### Preconditions
 
-The JAWS - UG management team welcomes all those who contribute something to the JAWS - UG community as core members. Core members are grouped by branch unit, but everyone is honored as a contributor representing that branch.
+* Please check the [Study Group List](https://jaws-ug.jp/act/) to see if there are any existing study groups in the same area or with the same theme. Please avoid creating two study groups with the same concept.
+* If there is a study group with the same concept that appears to be inactive, please contact us on the #general channel of the make-jawsug domain on Slack. With the cooperation of the people involved, please encourage the study group to be rebooted (restarted).
+* Please make sure there are multiple contributors. If you are recruiting, please organize the chapter concept and recruit in the #general channel of the make-jawsug domain on Slack.
+* To understand the management flow, please collaborate with an existing chapter and coordinate to become a sponsor of the chapter launch. If you are already active as a contributor to another chapter, a sponsor is not required.
 
-Participation in the core member is assumed to be participated when some kind of contribution is usually made, or at the preparation stage of a project etc. trying to contribute, when respect and mutual trust relationships from other core members are established doing.
+### Chapter Establishment Procedure
 
-All the core members in the branch have a flat relationship, but it is obvious that core members who compile opinions within the branch or take on a specific task at the same time will voluntarily occur inevitably is. In that case, there is no problem externally asking for "advertisement manager," "banquet manager," "advertisement sales", "contact manager" etc, but this is not an authority but a role (role).
+* Check the [JAWS-UG Slack team](https://jaws-ug.jp/jaws-ug-slack/) and register with the make-jawsug domain on Slack.
+* After organizing the following information, make a declaration of the establishment of the chapter in the #general channel and obtain agreement.
 
+* Chapter name
+* Concept
+* Contributors
+* Sponsor (not required if the contributor is a member of an existing chapter)
+* Create an event page on Connpass and add “JAWS-UG Secretariat” as an administrator
+* https://connpass.com/user/jaws-ug/
 
-# About the launch of the new branch
+### About active and dormant chapters
+Chapters that are active and displayed on the [list of study groups](https://jaws-ug.jp/act/) are recognized by JAWS-UG and Amazon Web Services Japan (AWS Japan). For a list of all study groups, including active and inactive groups, please refer to [this page](https://docs.google.com/spreadsheets/d/18ceDqZoXyFT92S7MwsvS9a6SrKnd0D1gssKJkDzIE4g/edit?usp=sharing)
 
-Existing branches are not moving · Contributors who want to discuss on branding chapters that are not in the area or have no existing theme can newly launch the branch freely. Please contact an existing contributor.
+#### Changing to Inactive Status
+The switch from “active” to “inactive” is done in the following order.
+- At the JAWS-UG general meeting held every March, we will contact chapters that have not held any study sessions for 12 months.
+- Chapters that have not held any study sessions for one month after being contacted will be treated as “inactive”.
+- We will contact the JAWS-UG General Assembly, #core-members${yyyymm}, and [Chapter Representatives](https://docs.google.com/spreadsheets/d/18ceDqZoXyFT92S7MwsvS9a6SrKnd0D1gssKJkDzIE4g/edit?usp=sharing), but even if we are unable to contact them, they will be treated as “inactive”.
+- yyyymm is created in units of years
 
-However, before planning the launch of the new branch, please go to the existing study group and the event and try to grasp the atmosphere. It is not too late to take a communication with the core members who manage the study group, grasp the entity of operation, and planning to launch a branch.
+#### Changing to an active status
+The switch from “inactive” to “active” is done in the following order.
+- The study group activity is restarted.
+- After the study group is held, contact is made with the JAWS-UG secretariat.
 
-If you received contact, please declare branch establishment as follows. However, please consider the preconditions.
+#### The reason for managing active and inactive status
+This is because in the past there were chapters that did not hold study sessions but only borrowed the name of JAWS-UG to show off their influence. In order to avoid this situation and to be able to support chapters that are active, we are managing active and dormant chapters.
 
-### Prerequisites
+## About this code of conduct
 
-* Please check if there are existing branches in the same area and the same theme. Avoid two branches in the same concept as much as possible.
-* If there is a branch of the same concept but it does not seem to be active, please recommend rebooting (rebooting) its branch under the cooperation of concerned parties.
-
-### Branch establishment procedure
-
-* Please enter your email address in [this form] (http://goo.gl/forms/srLWO5cKxS) and register it in Slack's make-jawsug domain.
-* After setting the icon to be easy to understand, please introduce yourself easily with the #general channel and declare the branch established.
-* Contents of the declaration should be agreed by posting "branch name", "place of treatment, theme such as theme summary" etc.
-
-Due to historical circumstances, there are also many information exchanges at [Facebook Group] (https://www.facebook.com/groups/209654002458990/). Please also register for us.
-
-For specific procedures and work after declaration, please ask existing contributors for support or [this document] (https://www.facebook.com/notes/jaws-ug%E5%85%A8%E5%9B%BD/jaws-ug%E6%94%AF%E9%83%A8%E7%AB%8B%E3%81%A1%E4%B8%8A%E3%81%92%E3%81%AE%E3%82%BF%E3%82%B9%E3%82%AF/467900496634338).
-
-### About this Code of Conduct
-Contributors will discuss this code of conduct in an open place and will continue to modify it to be suitable for the situation of JAWS-UG at that time. Those who have an opinion on this code of conduct can openly discuss at slack above, participants should not disturb it.
+This code of conduct is to be discussed by contributors in an open forum, and will be continually revised to suit the current situation of JAWS-UG. Those who have opinions on this code of conduct can openly discuss them on the above slack, and participants should avoid preventing this.

--- a/for-contributors.md
+++ b/for-contributors.md
@@ -70,7 +70,8 @@ JAWS-UG運営チームは、JAWS-UGコミュニティに対して何らかの貢
 ”活動中”から”休眠中”の切り替えは以下順序にて行います。
 - 毎年3月に開催されるJAWS-UG総会にて、12ヶ月間勉強会活動がない支部に対して連絡を行います。
 - 連絡後1ヶ月間で勉強会活動がない支部は”休眠中”の扱いとします。
-- 連絡はJAWS-UG総会、#core-members、[支部代表者](https://docs.google.com/spreadsheets/d/18ceDqZoXyFT92S7MwsvS9a6SrKnd0D1gssKJkDzIE4g/edit?usp=sharing)に対して行いますが、連絡が取れない場合においても”休眠中”の扱いとします。
+- 連絡はJAWS-UG総会、#core-members${yyyymm}、[支部代表者](https://docs.google.com/spreadsheets/d/18ceDqZoXyFT92S7MwsvS9a6SrKnd0D1gssKJkDzIE4g/edit?usp=sharing)に対して行いますが、連絡が取れない場合においても”休眠中”の扱いとします。
+  - yyyymmは年度単位での作成となります
 
 #### 活動中ステータスへの変更について
 ”休眠中”から”活動中”の切り替えは以下順序にて行います。

--- a/for-contributors.md
+++ b/for-contributors.md
@@ -70,8 +70,8 @@ JAWS-UG運営チームは、JAWS-UGコミュニティに対して何らかの貢
 ”活動中”から”休眠中”の切り替えは以下順序にて行います。
 - 毎年3月に開催されるJAWS-UG総会にて、12ヶ月間勉強会活動がない支部に対して連絡を行います。
 - 連絡後1ヶ月間で勉強会活動がない支部は”休眠中”の扱いとします。
-- 連絡はJAWS-UG総会、#core-members${yyyymm}、[支部代表者](https://docs.google.com/spreadsheets/d/18ceDqZoXyFT92S7MwsvS9a6SrKnd0D1gssKJkDzIE4g/edit?usp=sharing)に対して行いますが、連絡が取れない場合においても”休眠中”の扱いとします。
-  - yyyymmは年度単位での作成となります
+- 連絡はJAWS-UG総会、#core-members${yyyy}、[支部代表者](https://docs.google.com/spreadsheets/d/18ceDqZoXyFT92S7MwsvS9a6SrKnd0D1gssKJkDzIE4g/edit?usp=sharing)に対して行いますが、連絡が取れない場合においても”休眠中”の扱いとします。
+  - yyyyは年度単位での作成となります
 
 #### 活動中ステータスへの変更について
 ”休眠中”から”活動中”の切り替えは以下順序にて行います。


### PR DESCRIPTION
# 対応１
core-memberのチャンネルが年度単位に切り替わるため、yyyymmと表記しました。

# 対応２
英語が最新化されていなかったので DeepLを使って英訳しています。